### PR TITLE
Fix Chemical Hazard DB relation

### DIFF
--- a/src/TuDa.CIMS.Api/Migrations/20241205001612_FixHazards.Designer.cs
+++ b/src/TuDa.CIMS.Api/Migrations/20241205001612_FixHazards.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TuDa.CIMS.Api.Database;
@@ -11,9 +12,11 @@ using TuDa.CIMS.Api.Database;
 namespace TuDa.CIMS.Api.Migrations
 {
     [DbContext(typeof(CIMSDbContext))]
-    partial class CIMSDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241205001612_FixHazards")]
+    partial class FixHazards
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TuDa.CIMS.Api/Migrations/20241205001612_FixHazards.cs
+++ b/src/TuDa.CIMS.Api/Migrations/20241205001612_FixHazards.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TuDa.CIMS.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixHazards : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Hazards_AssetItems_ChemicalId",
+                table: "Hazards");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Hazards_ChemicalId",
+                table: "Hazards");
+
+            migrationBuilder.DropColumn(
+                name: "ChemicalId",
+                table: "Hazards");
+
+            migrationBuilder.CreateTable(
+                name: "ChemicalHazard",
+                columns: table => new
+                {
+                    ChemicalsId = table.Column<Guid>(type: "uuid", nullable: false),
+                    HazardsId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChemicalHazard", x => new { x.ChemicalsId, x.HazardsId });
+                    table.ForeignKey(
+                        name: "FK_ChemicalHazard_AssetItems_ChemicalsId",
+                        column: x => x.ChemicalsId,
+                        principalTable: "AssetItems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ChemicalHazard_Hazards_HazardsId",
+                        column: x => x.HazardsId,
+                        principalTable: "Hazards",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChemicalHazard_HazardsId",
+                table: "ChemicalHazard",
+                column: "HazardsId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ChemicalHazard");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ChemicalId",
+                table: "Hazards",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Hazards_ChemicalId",
+                table: "Hazards",
+                column: "ChemicalId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Hazards_AssetItems_ChemicalId",
+                table: "Hazards",
+                column: "ChemicalId",
+                principalTable: "AssetItems",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/src/TuDa.CIMS.Shared/Entities/Hazard.cs
+++ b/src/TuDa.CIMS.Shared/Entities/Hazard.cs
@@ -19,4 +19,9 @@ public record Hazard
     /// An Image of the hazard.
     /// </summary>
     public string ImagePath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// All chemicals that have this Hazard
+    /// </summary>
+    public List<Chemical> Chemicals { get; set; } = [];
 }


### PR DESCRIPTION
I worked on #51 and notices that Hazards are directly related to Chemicals with an N:1 relation, which is not right. 
This PR changes that. EF will now create a translation table named `ChemicalHazard` and they will have an N:M relation now.
This is especially important because the removal of Chemicals will not work without this change.