### PR TITLE
Add option to connect to Api without Aspire

### DIFF
--- a/src/TuDa.CIMS.Shared/Extensions/WebAppBuilderExtension.cs
+++ b/src/TuDa.CIMS.Shared/Extensions/WebAppBuilderExtension.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Refit;
@@ -9,9 +10,25 @@ namespace TuDa.CIMS.Shared.Extensions;
 public static class WebAppBuilderExtension
 {
     /// <summary>
-    /// Registers all RefitClients that have a <see cref="RefitClientAttribute"/>
-    /// The base url must be defined in the appsettings.json under `CIMS:Api`
+    /// Registers all Refit clients annotated with the <see cref="RefitClientAttribute"/>.
+    ///
+    /// <p>
+    ///     In development:
+    /// </p>
+    /// <ul>
+    ///     <li>
+    ///         If Aspire is used to start the project, 'Api:Aspire:ServiceName' need to be set.
+    ///         The base URL is derived from that service name
+    ///         and 'Api:Aspire:https' determines the protocol (HTTP/HTTPS).
+    ///     </li>
+    ///     <li>
+    ///         Otherwise, 'Api:BaseUrl' is used.
+    ///     </li>
+    /// </ul>
+    ///
+    /// In other environments, 'Api:BaseUrl' is required.
     /// </summary>
+    /// <exception cref="ArgumentException">If the necessary configuration keys are not present.</exception>
     public static TBuilder AddRefitClients<TBuilder>(this TBuilder builder)
         where TBuilder : IHostApplicationBuilder
     {
@@ -25,11 +42,39 @@ public static class WebAppBuilderExtension
                     .Services.AddRefitClient(clientType)
                     .ConfigureHttpClient(client =>
                         client.BaseAddress = new Uri(
-                            builder.Configuration["Api:BaseUrl"]!
+                            builder.GetApiBaseUrl()
                                 + clientType.GetCustomAttribute<RefitClientAttribute>()?.BaseRoute
                         )
                     )
             );
         return builder;
+    }
+
+    private static string GetApiBaseUrl<TBuilder>(this TBuilder builder)
+        where TBuilder : IHostApplicationBuilder
+    {
+        if (!builder.Environment.IsDevelopment())
+        {
+            return builder.Configuration["Api:BaseUrl"]
+                ?? throw new ArgumentException("Api:BaseUrl is not set");
+        }
+
+        string apiServiceName =
+            builder.Configuration["Api:Aspire:ServiceName"]
+            ?? throw new ArgumentException("Api:ServiceName is not set");
+
+        return builder.Configuration.Properties.TryGetValue(
+            $"services:{apiServiceName}",
+            out _
+        ) switch
+        {
+            false => builder.Configuration["Api:BaseUrl"]
+                ?? throw new ArgumentException("Api:BaseUrl is not set"),
+            true => (builder.Configuration.GetValue<bool?>("Api:Aspire:https") ?? false) switch
+            {
+                true => $"https://{apiServiceName}",
+                false => $"http://{apiServiceName}",
+            },
+        };
     }
 }

--- a/src/TuDa.CIMS.Web/appsettings.Development.json
+++ b/src/TuDa.CIMS.Web/appsettings.Development.json
@@ -6,6 +6,10 @@
     }
   },
   "Api": {
-    "BaseUrl": "http://cims-api"
+    "Aspire": {
+      "ServiceName": "cims-api",
+      "https": false
+    },
+    "BaseUrl": "http://localhost:5285"
   }
 }


### PR DESCRIPTION
At the moment, we can only connect to the API from the FE via Aspire **or** via localhost URL. 

Now a check if the FE is started by Aspire is done. If not, an alternative `BaseUrl` is used