### PR TITLE
Create invoice for a DateSpan

### DIFF
--- a/infrastructure/TuDa.CIMS.MigrationService/Worker.cs
+++ b/infrastructure/TuDa.CIMS.MigrationService/Worker.cs
@@ -91,10 +91,11 @@ public class Worker(
         var professor = new PersonFaker<Professor>().Generate();
         var students = new PersonFaker<Student>().GenerateBetween(5, 5);
 
-        var purchaseEntries = new PurchaseEntryFaker(chemical).GenerateBetween(4, 4);
-        var purchase = new PurchaseFaker(null, purchaseEntries).Generate();
+        var workingGroup = new WorkingGroupFaker(professor, students, []).Generate();
 
-        var workingGroup = new WorkingGroupFaker(professor, students, [purchase]).Generate();
+        var purchaseEntries = new PurchaseEntryFaker(chemical).GenerateBetween(4, 4);
+        var purchase = new PurchaseFaker(workingGroup, purchaseEntries).Generate();
+        workingGroup.Purchases.Add(purchase);
 
         var consumableTransaction = new ConsumableTransactionFaker(consumable).Generate();
 

--- a/src/TuDa.CIMS.Api/Controllers/InvoiceController.cs
+++ b/src/TuDa.CIMS.Api/Controllers/InvoiceController.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using TuDa.CIMS.Api.Interfaces;
+
+namespace TuDa.CIMS.Api.Controllers;
+
+[ApiController]
+[Route("api/invoices")]
+public class InvoiceController : ControllerBase
+{
+    private readonly IInvoiceGenerationService _invoiceService;
+
+    public InvoiceController(IInvoiceGenerationService invoiceService)
+    {
+        _invoiceService = invoiceService;
+    }
+
+    [HttpGet($"{{{nameof(workingGroupId)}:guid}}/statistics")]
+    public async Task<IActionResult> GetInvoiceStatistics(
+        Guid workingGroupId,
+        [FromQuery] DateOnly? beginDate,
+        [FromQuery] DateOnly? endDate
+    ) =>
+        (
+            await _invoiceService.GetInvoiceStatistics(workingGroupId, beginDate, endDate)
+        ).Match<IActionResult>(Ok, BadRequest);
+}

--- a/src/TuDa.CIMS.Api/Interfaces/IInvoiceGenerationService.cs
+++ b/src/TuDa.CIMS.Api/Interfaces/IInvoiceGenerationService.cs
@@ -1,0 +1,12 @@
+﻿using TuDa.CIMS.Api.Models;
+
+namespace TuDa.CIMS.Api.Interfaces;
+
+public interface IInvoiceGenerationService
+{
+    public Task<ErrorOr<Invoice>> CollectInvoiceForWorkingGroup(
+        Guid workingGroupId,
+        DateOnly beginDate,
+        DateOnly endDate
+    );
+}

--- a/src/TuDa.CIMS.Api/Interfaces/IInvoiceGenerationService.cs
+++ b/src/TuDa.CIMS.Api/Interfaces/IInvoiceGenerationService.cs
@@ -1,4 +1,5 @@
 ﻿using TuDa.CIMS.Api.Models;
+using TuDa.CIMS.Shared.Models;
 
 namespace TuDa.CIMS.Api.Interfaces;
 
@@ -6,7 +7,13 @@ public interface IInvoiceGenerationService
 {
     public Task<ErrorOr<Invoice>> CollectInvoiceForWorkingGroup(
         Guid workingGroupId,
-        DateOnly beginDate,
-        DateOnly endDate
+        DateOnly? beginDate,
+        DateOnly? endDate
+    );
+
+    public Task<ErrorOr<InvoiceStatistics>> GetInvoiceStatistics(
+        Guid workingGroupId,
+        DateOnly? beginDate,
+        DateOnly? endDate
     );
 }

--- a/src/TuDa.CIMS.Api/Interfaces/IInvoiceRepository.cs
+++ b/src/TuDa.CIMS.Api/Interfaces/IInvoiceRepository.cs
@@ -1,0 +1,15 @@
+﻿using TuDa.CIMS.Api.Models;
+using TuDa.CIMS.Shared.Entities;
+
+namespace TuDa.CIMS.Api.Interfaces;
+
+public interface IInvoiceRepository
+{
+    public Task<List<Purchase>> GetPurchasesInTimePeriod(
+        Guid workingGroupId,
+        DateTime beginDate,
+        DateTime endDate
+    );
+
+    public Task<Professor> GetProfessorOfWorkingGroup(Guid workingGroupId);
+}

--- a/src/TuDa.CIMS.Api/Interfaces/IInvoiceRepository.cs
+++ b/src/TuDa.CIMS.Api/Interfaces/IInvoiceRepository.cs
@@ -11,5 +11,5 @@ public interface IInvoiceRepository
         DateTime endDate
     );
 
-    public Task<Professor> GetProfessorOfWorkingGroup(Guid workingGroupId);
+    public Task<Professor?> GetProfessorOfWorkingGroup(Guid workingGroupId);
 }

--- a/src/TuDa.CIMS.Api/Models/Invoice.cs
+++ b/src/TuDa.CIMS.Api/Models/Invoice.cs
@@ -52,30 +52,33 @@ public record Invoice
     /// Gets the total price of all entries in the invoice.
     /// </summary>
     public double TotalPrice =>
-        ConsumablesTotalPrice + ChemicalsTotalPrice + SolventsTotalPrice + GasCylindersTotalPrice;
+        ConsumablesTotalPrice()
+        + ChemicalsTotalPrice()
+        + SolventsTotalPrice()
+        + GasCylindersTotalPrice();
 
     /// <summary>
     /// Gets the total price of all consumable entries in the invoice.
     /// </summary>
-    public double ConsumablesTotalPrice =>
+    public double ConsumablesTotalPrice() =>
         Consumables.Aggregate(0.0, (state, entry) => state + entry.TotalPrice);
 
     /// <summary>
     /// Gets the total price of all chemical entries in the invoice.
     /// </summary>
-    public double ChemicalsTotalPrice =>
+    public double ChemicalsTotalPrice() =>
         Chemicals.Aggregate(0.0, (state, entry) => state + entry.TotalPrice);
 
     /// <summary>
     /// Gets the total price of all solvent entries in the invoice.
     /// </summary>
-    public double SolventsTotalPrice =>
+    public double SolventsTotalPrice() =>
         Solvents.Aggregate(0.0, (state, entry) => state + entry.TotalPrice);
 
     /// <summary>
     /// Gets the total price of all gas cylinder entries in the invoice.
     /// </summary>
-    public double GasCylindersTotalPrice =>
+    public double GasCylindersTotalPrice() =>
         GasCylinders.Aggregate(0.0, (state, entry) => state + entry.TotalPrice);
 
     #endregion

--- a/src/TuDa.CIMS.Api/Models/Invoice.cs
+++ b/src/TuDa.CIMS.Api/Models/Invoice.cs
@@ -1,0 +1,82 @@
+﻿using TuDa.CIMS.Shared.Entities;
+
+namespace TuDa.CIMS.Api.Models;
+
+/// <summary>
+/// Represents an invoice with details about the billing period, professor, and various entries.
+/// </summary>
+public record Invoice
+{
+    /// <summary>
+    /// The start date of the billing period.
+    /// </summary>
+    public required DateOnly BeginDate { get; init; }
+
+    /// <summary>
+    /// The end date of the billing period.
+    /// </summary>
+    public required DateOnly EndDate { get; init; }
+
+    /// <summary>
+    /// The professor associated with the invoice.
+    /// </summary>
+    public required Professor Professor { get; init; }
+
+    #region Entries
+
+    /// <summary>
+    /// The list of consumable entries in the invoice.
+    /// </summary>
+    public List<InvoiceEntry> Consumables { get; init; } = [];
+
+    /// <summary>
+    /// The list of chemical entries in the invoice.
+    /// </summary>
+    public List<InvoiceEntry> Chemicals { get; init; } = [];
+
+    /// <summary>
+    /// The list of solvent entries in the invoice.
+    /// </summary>
+    public List<InvoiceEntry> Solvents { get; init; } = [];
+
+    /// <summary>
+    /// The list of gas cylinder entries in the invoice.
+    /// </summary>
+    public List<InvoiceEntry> GasCylinders { get; init; } = [];
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Gets the total price of all entries in the invoice.
+    /// </summary>
+    public double TotalPrice =>
+        ConsumablesTotalPrice + ChemicalsTotalPrice + SolventsTotalPrice + GasCylindersTotalPrice;
+
+    /// <summary>
+    /// Gets the total price of all consumable entries in the invoice.
+    /// </summary>
+    public double ConsumablesTotalPrice =>
+        Consumables.Aggregate(0.0, (state, entry) => state + entry.TotalPrice);
+
+    /// <summary>
+    /// Gets the total price of all chemical entries in the invoice.
+    /// </summary>
+    public double ChemicalsTotalPrice =>
+        Chemicals.Aggregate(0.0, (state, entry) => state + entry.TotalPrice);
+
+    /// <summary>
+    /// Gets the total price of all solvent entries in the invoice.
+    /// </summary>
+    public double SolventsTotalPrice =>
+        Solvents.Aggregate(0.0, (state, entry) => state + entry.TotalPrice);
+
+    /// <summary>
+    /// Gets the total price of all gas cylinder entries in the invoice.
+    /// </summary>
+    public double GasCylindersTotalPrice =>
+        GasCylinders.Aggregate(0.0, (state, entry) => state + entry.TotalPrice);
+
+    #endregion
+}

--- a/src/TuDa.CIMS.Api/Models/InvoiceEntry.cs
+++ b/src/TuDa.CIMS.Api/Models/InvoiceEntry.cs
@@ -1,0 +1,19 @@
+﻿using TuDa.CIMS.Shared.Entities;
+
+namespace TuDa.CIMS.Api.Models;
+
+/// <summary>
+/// Represents an entry in an invoice, inheriting from PurchaseEntry.
+/// </summary>
+public record InvoiceEntry : PurchaseEntry
+{
+    /// <summary>
+    /// The date of the entry.
+    /// </summary>
+    public required DateOnly PurchaseDate { get; init; }
+
+    /// <summary>
+    /// The buyer of the entry.
+    /// </summary>
+    public required Person Buyer { get; init; }
+}

--- a/src/TuDa.CIMS.Api/Program.cs
+++ b/src/TuDa.CIMS.Api/Program.cs
@@ -29,4 +29,3 @@ if (app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 
 await app.RunAsync();
-

--- a/src/TuDa.CIMS.Api/Repositories/InvoiceRepository.cs
+++ b/src/TuDa.CIMS.Api/Repositories/InvoiceRepository.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore;
+using TuDa.CIMS.Api.Database;
+using TuDa.CIMS.Api.Interfaces;
+using TuDa.CIMS.Shared.Entities;
+
+namespace TuDa.CIMS.Api.Repositories;
+
+public class InvoiceRepository : IInvoiceRepository
+{
+    private readonly CIMSDbContext _context;
+
+    public InvoiceRepository(CIMSDbContext context)
+    {
+        _context = context;
+    }
+
+    public Task<List<Purchase>> GetPurchasesInTimePeriod(
+        Guid workingGroupId,
+        DateTime beginDate,
+        DateTime endDate
+    ) =>
+        _context
+            .WorkingGroups.Where(wg => wg.Id == workingGroupId)
+            .SelectMany(wg => wg.Purchases)
+            .Where(p =>
+                (p.Completed && p.CompletionDate != null)
+                && (p.CompletionDate.Value >= beginDate && p.CompletionDate.Value <= endDate)
+            )
+            .ToListAsync();
+
+    public Task<Professor> GetProfessorOfWorkingGroup(Guid workingGroupId) =>
+        _context
+            .WorkingGroups.Where(wg => wg.Id == workingGroupId)
+            .Select(wg => wg.Professor)
+            .SingleAsync();
+}

--- a/src/TuDa.CIMS.Api/Repositories/InvoiceRepository.cs
+++ b/src/TuDa.CIMS.Api/Repositories/InvoiceRepository.cs
@@ -21,16 +21,20 @@ public class InvoiceRepository : IInvoiceRepository
     ) =>
         _context
             .WorkingGroups.Where(wg => wg.Id == workingGroupId)
+            .Include(wg => wg.Purchases)
             .SelectMany(wg => wg.Purchases)
             .Where(p =>
                 (p.Completed && p.CompletionDate != null)
                 && (p.CompletionDate.Value >= beginDate && p.CompletionDate.Value <= endDate)
             )
+            .Include(p => p.Entries)
+            .ThenInclude(e => e.AssetItem)
+            .Include(p => p.Buyer)
             .ToListAsync();
 
-    public Task<Professor> GetProfessorOfWorkingGroup(Guid workingGroupId) =>
+    public Task<Professor?> GetProfessorOfWorkingGroup(Guid workingGroupId) =>
         _context
             .WorkingGroups.Where(wg => wg.Id == workingGroupId)
             .Select(wg => wg.Professor)
-            .SingleAsync();
+            .SingleOrDefaultAsync();
 }

--- a/src/TuDa.CIMS.Api/Repositories/InvoiceRepository.cs
+++ b/src/TuDa.CIMS.Api/Repositories/InvoiceRepository.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using TuDa.CIMS.Api.Database;
 using TuDa.CIMS.Api.Interfaces;
+using TuDa.CIMS.Shared.Attributes.ServiceRegistration;
 using TuDa.CIMS.Shared.Entities;
 
 namespace TuDa.CIMS.Api.Repositories;
 
+[ScopedService]
 public class InvoiceRepository : IInvoiceRepository
 {
     private readonly CIMSDbContext _context;

--- a/src/TuDa.CIMS.Api/Services/InvoiceGenerationService.cs
+++ b/src/TuDa.CIMS.Api/Services/InvoiceGenerationService.cs
@@ -1,0 +1,68 @@
+﻿using Mapster;
+using TuDa.CIMS.Api.Interfaces;
+using TuDa.CIMS.Api.Models;
+using TuDa.CIMS.Shared.Entities;
+
+namespace TuDa.CIMS.Api.Services;
+
+public class InvoiceGenerationService : IInvoiceGenerationService
+{
+    private readonly IInvoiceRepository _invoiceRepository;
+
+    public InvoiceGenerationService(IInvoiceRepository invoiceRepository)
+    {
+        _invoiceRepository = invoiceRepository;
+    }
+
+    public async Task<ErrorOr<Invoice>> CollectInvoiceForWorkingGroup(
+        Guid workingGroupId,
+        DateOnly beginDate,
+        DateOnly endDate
+    )
+    {
+        try
+        {
+            var purchasesInTimePeriod = await _invoiceRepository.GetPurchasesInTimePeriod(
+                workingGroupId,
+                beginDate.ToDateTime(TimeOnly.MinValue),
+                endDate.ToDateTime(TimeOnly.MinValue)
+            );
+
+            var professor = await _invoiceRepository.GetProfessorOfWorkingGroup(workingGroupId);
+
+            var invoiceEntries = purchasesInTimePeriod
+                .SelectMany(MapPurchaseToInvoiceEntries)
+                .ToLookup(e => e.AssetItem.GetType());
+
+            return new Invoice
+            {
+                BeginDate = beginDate,
+                EndDate = endDate,
+                Professor = professor,
+                Consumables = invoiceEntries[typeof(Consumable)].ToList(),
+                Chemicals = invoiceEntries[typeof(Chemical)].ToList(),
+                Solvents = invoiceEntries[typeof(Solvent)].ToList(),
+                GasCylinders = invoiceEntries[typeof(GasCylinder)].ToList(),
+            };
+        }
+        catch (Exception e)
+        {
+            return Error.Failure(
+                $"{nameof(InvoiceGenerationService)}.{nameof(CollectInvoiceForWorkingGroup)}",
+                e.Message
+            );
+        }
+    }
+
+    private static List<InvoiceEntry> MapPurchaseToInvoiceEntries(Purchase purchase) =>
+        purchase
+            .Entries.Select(e => new InvoiceEntry
+            {
+                AssetItem = e.AssetItem,
+                Amount = e.Amount,
+                PricePerItem = e.PricePerItem,
+                PurchaseDate = DateOnly.FromDateTime(purchase.CompletionDate!.Value),
+                Buyer = purchase.Buyer,
+            })
+            .ToList();
+}

--- a/src/TuDa.CIMS.Api/Services/InvoiceGenerationService.cs
+++ b/src/TuDa.CIMS.Api/Services/InvoiceGenerationService.cs
@@ -1,10 +1,12 @@
 ﻿using TuDa.CIMS.Api.Interfaces;
 using TuDa.CIMS.Api.Models;
+using TuDa.CIMS.Shared.Attributes.ServiceRegistration;
 using TuDa.CIMS.Shared.Entities;
 using TuDa.CIMS.Shared.Models;
 
 namespace TuDa.CIMS.Api.Services;
 
+[ScopedService]
 public class InvoiceGenerationService : IInvoiceGenerationService
 {
     private readonly IInvoiceRepository _invoiceRepository;

--- a/src/TuDa.CIMS.Shared/Models/InvoiceStatistics.cs
+++ b/src/TuDa.CIMS.Shared/Models/InvoiceStatistics.cs
@@ -1,0 +1,9 @@
+﻿namespace TuDa.CIMS.Shared.Models;
+
+public record InvoiceStatistics
+{
+    public required double TotalPriceConsumables { get; set; }
+    public required double TotalPriceChemicals { get; set; }
+    public required double TotalPriceSolvents { get; set; }
+    public required double TotalPriceGasCylinders { get; set; }
+}

--- a/test/TuDa.CIMS.Api.Test/Services/InvoiceGenerationServiceTest.cs
+++ b/test/TuDa.CIMS.Api.Test/Services/InvoiceGenerationServiceTest.cs
@@ -1,0 +1,132 @@
+﻿using Bogus;
+using JetBrains.Annotations;
+using TuDa.CIMS.Api.Interfaces;
+using TuDa.CIMS.Api.Services;
+using TuDa.CIMS.Shared.Entities;
+using TuDa.CIMS.Shared.Test.Faker;
+
+namespace TuDa.CIMS.Api.Test.Services;
+
+[TestSubject(typeof(InvoiceGenerationService))]
+public class InvoiceGenerationServiceTest
+{
+    private readonly Mock<IInvoiceRepository> _mockInvoiceRepository = new();
+    private readonly IInvoiceGenerationService _invoiceGeneration;
+
+    public InvoiceGenerationServiceTest()
+    {
+        _invoiceGeneration = new InvoiceGenerationService(_mockInvoiceRepository.Object);
+    }
+
+    [Fact]
+    public async Task CollectingInvoiceEntriesCorrectlyFromOnePurchase()
+    {
+        var workingGroup = new WorkingGroupFaker().Generate();
+        var purchase = new PurchaseFaker(workingGroup, completed: true).Generate();
+        Consumable consumable = new ConsumableFaker();
+        Chemical chemical = new ChemicalFaker();
+        Solvent solvent = new SolventFaker();
+        GasCylinder gas = new GasCylinderFaker();
+
+        purchase.Entries =
+        [
+            new PurchaseEntryFaker(consumable),
+            new PurchaseEntryFaker(chemical),
+            new PurchaseEntryFaker(solvent),
+            new PurchaseEntryFaker(gas),
+        ];
+        workingGroup.Purchases = [purchase];
+
+        _mockInvoiceRepository
+            .Setup(r => r.GetProfessorOfWorkingGroup(workingGroup.Id))
+            .ReturnsAsync(workingGroup.Professor);
+
+        _mockInvoiceRepository
+            .Setup(r =>
+                r.GetPurchasesInTimePeriod(
+                    workingGroup.Id,
+                    It.IsAny<DateTime>(),
+                    It.IsAny<DateTime>()
+                )
+            )
+            .ReturnsAsync(workingGroup.Purchases);
+
+        var errorOrInvoice = await _invoiceGeneration.CollectInvoiceForWorkingGroup(
+            workingGroup.Id,
+            DateOnly.MinValue,
+            DateOnly.MaxValue
+        );
+
+        errorOrInvoice.IsError.Should().BeFalse();
+        errorOrInvoice.Value.Should().NotBeNull();
+
+        var invoice = errorOrInvoice.Value;
+        invoice.Professor.Should().Be(workingGroup.Professor);
+        invoice.BeginDate.Should().Be(DateOnly.MinValue);
+        invoice.EndDate.Should().Be(DateOnly.MaxValue);
+
+        invoice.Consumables.Single().AssetItem.Should().Be(consumable);
+        invoice.Chemicals.Single().AssetItem.Should().Be(chemical);
+        invoice.Solvents.Single().AssetItem.Should().Be(solvent);
+        invoice.GasCylinders.Single().AssetItem.Should().Be(gas);
+    }
+
+    [Fact]
+    public async Task CollectingInvoiceEntriesCorrectlyFromMultiplePurchase()
+    {
+        var workingGroup = new WorkingGroupFaker().Generate();
+        var purchase = new PurchaseFaker(workingGroup, completed: true).GenerateBetween(2, 5);
+        Consumable consumable = new ConsumableFaker();
+        Chemical chemical = new ChemicalFaker();
+        Solvent solvent = new SolventFaker();
+        GasCylinder gas = new GasCylinderFaker();
+
+        workingGroup.Purchases = purchase
+            .Select(p =>
+                p with
+                {
+                    Entries =
+                    [
+                        new PurchaseEntryFaker(consumable),
+                        new PurchaseEntryFaker(chemical),
+                        new PurchaseEntryFaker(solvent),
+                        new PurchaseEntryFaker(gas),
+                    ],
+                }
+            )
+            .ToList();
+
+        _mockInvoiceRepository
+            .Setup(r => r.GetProfessorOfWorkingGroup(workingGroup.Id))
+            .ReturnsAsync(workingGroup.Professor);
+
+        _mockInvoiceRepository
+            .Setup(r =>
+                r.GetPurchasesInTimePeriod(
+                    workingGroup.Id,
+                    It.IsAny<DateTime>(),
+                    It.IsAny<DateTime>()
+                )
+            )
+            .ReturnsAsync(workingGroup.Purchases);
+
+        var errorOrInvoice = await _invoiceGeneration.CollectInvoiceForWorkingGroup(
+            workingGroup.Id,
+            DateOnly.MinValue,
+            DateOnly.MaxValue
+        );
+
+        errorOrInvoice.IsError.Should().BeFalse();
+        errorOrInvoice.Value.Should().NotBeNull();
+
+        var invoice = errorOrInvoice.Value;
+        invoice.Professor.Should().Be(workingGroup.Professor);
+        invoice.BeginDate.Should().Be(DateOnly.MinValue);
+        invoice.EndDate.Should().Be(DateOnly.MaxValue);
+
+        invoice.Consumables.Select(e => e.AssetItem).Should().AllBeOfType<Consumable>();
+        invoice.Chemicals.Select(e => e.AssetItem).Should().AllBeOfType<Chemical>();
+        invoice.Solvents.Select(e => e.AssetItem).Should().AllBeOfType<Solvent>();
+        invoice.GasCylinders.Select(e => e.AssetItem).Should().AllBeOfType<GasCylinder>();
+    }
+}

--- a/test/TuDa.CIMS.Api.Test/TuDa.CIMS.Api.Test.csproj
+++ b/test/TuDa.CIMS.Api.Test/TuDa.CIMS.Api.Test.csproj
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/test/TuDa.CIMS.Api.Test/UnitTest1.cs
+++ b/test/TuDa.CIMS.Api.Test/UnitTest1.cs
@@ -1,9 +1,0 @@
-namespace TuDa.CIMS.Api.Test;
-
-public class UnitTest1
-{
-    [Fact]
-    public void Test1()
-    {
-    }
-}

--- a/test/TuDa.CIMS.Api.Test/Usings.cs
+++ b/test/TuDa.CIMS.Api.Test/Usings.cs
@@ -1,0 +1,2 @@
+﻿global using FluentAssertions;
+global using Moq;

--- a/test/TuDa.CIMS.Shared.Test/Faker/PurchaseFaker.cs
+++ b/test/TuDa.CIMS.Shared.Test/Faker/PurchaseFaker.cs
@@ -6,13 +6,12 @@ namespace TuDa.CIMS.Shared.Test.Faker;
 public class PurchaseFaker : BaseEntityFaker<Purchase>
 {
     public PurchaseFaker(
-        WorkingGroup? workingGroup = null,
+        WorkingGroup workingGroup,
         List<PurchaseEntry>? purchaseEntries = null,
         bool? completed = null
     )
     {
         completed ??= new Randomizer().Bool();
-        workingGroup ??= new WorkingGroupFaker();
 
         RuleFor(p => p.Buyer, f => f.PickRandom(workingGroup.Students));
         RuleFor(


### PR DESCRIPTION
This PR introduces a feature to generate an `Invoice` for a specific `WorkingGroup` within a defined time span.

Key additions include a dedicated service to handle invoice creation and corresponding tests for the service. Additionally, a statistics endpoint has been implemented to retrieve the total costs of all `AssetItem` categories.