### PR TITLE
Add enum string decoder in API

### DIFF
--- a/src/TuDa.CIMS.Api/ConfigureServices.cs
+++ b/src/TuDa.CIMS.Api/ConfigureServices.cs
@@ -1,4 +1,5 @@
-﻿using Scalar.AspNetCore;
+﻿using System.Text.Json.Serialization;
+using Scalar.AspNetCore;
 
 namespace TuDa.CIMS.Api;
 
@@ -20,5 +21,18 @@ public static class ConfigureServices
         });
 
         return app;
+    }
+
+    public static IServiceCollection AddJsonDecoder(this IServiceCollection services)
+    {
+        services.ConfigureHttpJsonOptions(options =>
+        {
+            options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
+        services.Configure<Microsoft.AspNetCore.Mvc.JsonOptions>(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
+        return services;
     }
 }

--- a/src/TuDa.CIMS.Api/Program.cs
+++ b/src/TuDa.CIMS.Api/Program.cs
@@ -17,6 +17,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddOpenApi();
 builder.Services.AddServices();
 builder.Services.AddProblemDetails();
+builder.Services.AddJsonDecoder();
 
 builder.Services.AddControllers();
 

--- a/src/TuDa.CIMS.Web/Extensions/ApiResponseExtension.cs
+++ b/src/TuDa.CIMS.Web/Extensions/ApiResponseExtension.cs
@@ -49,6 +49,7 @@ public static class ApiResponseExtension
                 { "url", exception.Uri?.ToString() ?? "None" },
                 { "method", exception.HttpMethod },
                 { "data", exception.Data },
+                { "problemDetails", exception.Content ?? string.Empty },
             }
         );
     }

--- a/test/TuDa.CIMS.Api.Test/Controllers/AssetItemControllerTest.cs
+++ b/test/TuDa.CIMS.Api.Test/Controllers/AssetItemControllerTest.cs
@@ -86,7 +86,7 @@ public class AssetItemControllerTest : IClassFixture<CIMSApiFactory>
         // Assert
         response.IsSuccessStatusCode.Should().BeTrue();
 
-        var result = await response.Content.ReadFromJsonAsync<List<AssetItem>>();
+        var result = await response.Content.FromJsonAsync<List<AssetItem>>();
 
         result.Should().BeEquivalentTo(assetItems);
     }
@@ -207,8 +207,8 @@ public class AssetItemControllerTest : IClassFixture<CIMSApiFactory>
         response3.IsSuccessStatusCode.Should().BeFalse();
         response3.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var result1 = await response1.Content.ReadFromJsonAsync<List<AssetItem>>();
-        var result2 = await response2.Content.ReadFromJsonAsync<List<AssetItem>>();
+        var result1 = await response1.Content.FromJsonAsync<List<AssetItem>>();
+        var result2 = await response2.Content.FromJsonAsync<List<AssetItem>>();
 
         result1.Should().BeEquivalentTo(assetItems[..2]);
         result2.Should().BeEquivalentTo(assetItems[2..4]);

--- a/test/TuDa.CIMS.Api.Test/Controllers/ConsumableTransactionTest.cs
+++ b/test/TuDa.CIMS.Api.Test/Controllers/ConsumableTransactionTest.cs
@@ -84,7 +84,7 @@ public class ConsumableTransactionTest : IClassFixture<CIMSApiFactory>
         // Assert
         response.IsSuccessStatusCode.Should().BeTrue();
 
-        var result = await response.Content.ReadFromJsonAsync<List<ConsumableTransaction>>();
+        var result = await response.Content.FromJsonAsync<List<ConsumableTransaction>>();
 
         result.Should().BeEquivalentTo(consumableTransactions);
     }
@@ -95,13 +95,13 @@ public class ConsumableTransactionTest : IClassFixture<CIMSApiFactory>
         // Arrange
         var consumables = new List<Consumable> { new ConsumableFaker(), new ConsumableFaker() };
 
-        var WorkingGroupFaker = new WorkingGroupFaker(purchases:[]).Generate();
+        var WorkingGroupFaker = new WorkingGroupFaker(purchases: []).Generate();
 
         _dbContext.WorkingGroups.Add(WorkingGroupFaker);
         _dbContext.AssetItems.AddRange(consumables);
         _dbContext.SaveChanges();
 
- var entries = consumables
+        var entries = consumables
             .Select(consumable => new CreatePurchaseEntryDto()
             {
                 AssetItemId = consumable.Id,
@@ -141,6 +141,5 @@ public class ConsumableTransactionTest : IClassFixture<CIMSApiFactory>
             entry.Amount.Should().Be(-transaction.AmountChange);
             entry.AssetItemId.Should().Be(transaction.Consumable.Id);
         }
-
     }
 }

--- a/test/TuDa.CIMS.Api.Test/Controllers/PurchaseControllerTest.cs
+++ b/test/TuDa.CIMS.Api.Test/Controllers/PurchaseControllerTest.cs
@@ -45,7 +45,7 @@ public class PurchaseControllerTest : IClassFixture<CIMSApiFactory>
             // Assert
             response.IsSuccessStatusCode.Should().BeTrue();
 
-            var result = await response.Content.ReadFromJsonAsync<Purchase>();
+            var result = await response.Content.FromJsonAsync<Purchase>();
 
             result.Should().BeEquivalentTo(purchase);
         }
@@ -75,7 +75,7 @@ public class PurchaseControllerTest : IClassFixture<CIMSApiFactory>
         // Assert
         response.IsSuccessStatusCode.Should().BeTrue();
 
-        var result = await response.Content.ReadFromJsonAsync<List<Purchase>>();
+        var result = await response.Content.FromJsonAsync<List<Purchase>>();
 
         result.Should().BeEquivalentTo(workingGroup.Purchases);
     }

--- a/test/TuDa.CIMS.Api.Test/Controllers/WorkingGroupControllerTest.cs
+++ b/test/TuDa.CIMS.Api.Test/Controllers/WorkingGroupControllerTest.cs
@@ -43,7 +43,7 @@ public class WorkingGroupControllerTest : IClassFixture<CIMSApiFactory>
         // Assert
         response.IsSuccessStatusCode.Should().BeTrue();
 
-        var result = await response.Content.ReadFromJsonAsync<WorkingGroup>();
+        var result = await response.Content.FromJsonAsync<WorkingGroup>();
 
         result.Should().BeEquivalentTo(workingGroup);
     }
@@ -72,7 +72,7 @@ public class WorkingGroupControllerTest : IClassFixture<CIMSApiFactory>
         // Assert
         response.IsSuccessStatusCode.Should().BeTrue();
 
-        var result = await response.Content.ReadFromJsonAsync<List<WorkingGroup>>();
+        var result = await response.Content.FromJsonAsync<List<WorkingGroup>>();
 
         result.Should().BeEquivalentTo(workingGroups);
     }
@@ -126,7 +126,7 @@ public class WorkingGroupControllerTest : IClassFixture<CIMSApiFactory>
         // Assert
         response.IsSuccessStatusCode.Should().BeTrue();
 
-        var createResult = await response.Content.ReadFromJsonAsync<WorkingGroup>();
+        var createResult = await response.Content.FromJsonAsync<WorkingGroup>();
 
         var result = await _dbContext.WorkingGroups.Include(wg => wg.Professor).SingleAsync();
         result
@@ -171,7 +171,7 @@ public class WorkingGroupControllerTest : IClassFixture<CIMSApiFactory>
         // Assert
         response.IsSuccessStatusCode.Should().BeTrue();
 
-        var responseWorkingGroup = await response.Content.ReadFromJsonAsync<WorkingGroup>();
+        var responseWorkingGroup = await response.Content.FromJsonAsync<WorkingGroup>();
 
         workingGroup.Should().BeEquivalentTo(updatedWorkingGroup);
 

--- a/test/TuDa.CIMS.Api.Test/Integration/CIMSApiFactory.cs
+++ b/test/TuDa.CIMS.Api.Test/Integration/CIMSApiFactory.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Testcontainers.PostgreSql;
 using TuDa.CIMS.Api.Database;
 
@@ -22,6 +23,10 @@ public class CIMSApiFactory : WebApplicationFactory<IApiMarker>, IAsyncLifetime
         {
             x.Remove(x.Single(a => typeof(DbContextOptions<CIMSDbContext>) == a.ServiceType));
             x.Remove(x.Single(a => typeof(CIMSDbContext) == a.ServiceType));
+            x.AddLogging(loggingBuilder =>
+            {
+                loggingBuilder.AddFilter("Microsoft.EntityFrameworkCore", LogLevel.Critical);
+            });
             x.AddDbContext<CIMSDbContext>(
                 a =>
                 {

--- a/test/TuDa.CIMS.Api.Test/JsonExtension.cs
+++ b/test/TuDa.CIMS.Api.Test/JsonExtension.cs
@@ -1,0 +1,21 @@
+﻿using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace TuDa.CIMS.Api.Test;
+
+public static class JsonExtension
+{
+    /// <summary>
+    /// TODO: This is a temporary solution to <see cref="System.Text.Json"/> not respecting any JsonConfiguration.
+    /// This does the same a <see cref="System.Net.Http.Json.HttpContentJsonExtensions.ReadFromJsonAsync"/> with enums as strings.
+    /// </summary>
+    public static async Task<TValue?> FromJsonAsync<TValue>(this HttpContent httpContent)
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new JsonStringEnumConverter());
+        options.PropertyNameCaseInsensitive = true;
+
+        return await httpContent.ReadFromJsonAsync<TValue>(options);
+    }
+}


### PR DESCRIPTION
Refit encodes `Enums` as strings. This allows the `Api` to handle these