### PR TITLE
Changed Required Input Fields & Separate Error Messages

### DIFF
--- a/src/TuDa.CIMS.Shared/Entities/Enums/MeasurementUnits.cs
+++ b/src/TuDa.CIMS.Shared/Entities/Enums/MeasurementUnits.cs
@@ -2,7 +2,6 @@
 
 public enum MeasurementUnits
 {
-    Unitless,
     MilliLiter,
     Liter,
     Gram,
@@ -20,7 +19,6 @@ public static class MeasurementUnitsExtension
             MeasurementUnits.Piece => "Stück",
             MeasurementUnits.MilliLiter => "ml",
             MeasurementUnits.Gram => "g",
-            MeasurementUnits.Unitless => "",
             _ => $" {unit}",
         };
 }

--- a/src/TuDa.CIMS.Shared/Entities/Enums/MeasurementUnits.cs
+++ b/src/TuDa.CIMS.Shared/Entities/Enums/MeasurementUnits.cs
@@ -2,6 +2,7 @@
 
 public enum MeasurementUnits
 {
+    Unitless,
     MilliLiter,
     Liter,
     Gram,
@@ -19,6 +20,7 @@ public static class MeasurementUnitsExtension
             MeasurementUnits.Piece => "Stück",
             MeasurementUnits.MilliLiter => "ml",
             MeasurementUnits.Gram => "g",
+            MeasurementUnits.Unitless => "",
             _ => $" {unit}",
         };
 }

--- a/src/TuDa.CIMS.Web/Components/Dashboard/Dialogs/AssetItemCreateForm.razor.cs
+++ b/src/TuDa.CIMS.Web/Components/Dashboard/Dialogs/AssetItemCreateForm.razor.cs
@@ -132,10 +132,10 @@ public partial class AssetItemCreateForm
                 Cas = _chemicalItemForm.FormCas,
                 Price = _assetItemForm.FormPrice,
                 Purity = _chemicalItemForm.FormPurity,
-                PriceUnit = _chemicalItemForm.FormPriceUnit,
+                PriceUnit = _chemicalItemForm.FormPriceUnit!.Value,
                 RoomId = RoomId,
             },
-            
+
             AssetItemType.Consumable => new CreateConsumableDto
             {
                 Name = _assetItemForm.FormName,
@@ -157,11 +157,11 @@ public partial class AssetItemCreateForm
                 Note = _assetItemForm.FormNote,
                 Price = _assetItemForm.FormPrice,
                 RoomId = RoomId,
-                Cas = _chemicalItemForm.FormCas,
-                Purity = _chemicalItemForm.FormPurity,
+                Cas = _gasCylinderForm.FormCas,
+                Purity = _gasCylinderForm.FormPurity,
                 Volume = _gasCylinderForm.FormVolume,
                 Pressure = _gasCylinderForm.FormPressure,
-                PriceUnit = _chemicalItemForm.FormPriceUnit,
+                PriceUnit = _gasCylinderForm.FormPriceUnit!.Value
             },
 
             AssetItemType.Solvent => new CreateSolventDto
@@ -173,7 +173,7 @@ public partial class AssetItemCreateForm
                 Cas = _chemicalItemForm.FormCas,
                 Price = _assetItemForm.FormPrice,
                 Purity = _chemicalItemForm.FormPurity,
-                PriceUnit = _chemicalItemForm.FormPriceUnit,
+                PriceUnit = _chemicalItemForm.FormPriceUnit!.Value,
                 RoomId = RoomId,
             },
 

--- a/src/TuDa.CIMS.Web/Components/Dashboard/Dialogs/AssetItemForm.razor
+++ b/src/TuDa.CIMS.Web/Components/Dashboard/Dialogs/AssetItemForm.razor
@@ -12,9 +12,9 @@
                   FullWidth/>
 
     <MudTextField @bind-Value="FormShop"
-                  Label="Shop"
+                  Label="Lieferant"
                   Error="@IsError"
-                  ErrorText="Der Shop muss eingegeben werden!"
+                  ErrorText="Der Lieferant muss eingegeben werden!"
                   Placeholder="Shop eingeben"
                   Variant="Variant.Filled"
                   FullWidth/>
@@ -43,8 +43,6 @@
 
     <MudTextField @bind-Value="FormRoomName"
                   Label="Raumname"
-                  Error="@IsError"
-                  ErrorText="Der Raumname muss eingegeben werden!"
                   Placeholder="Raumname eingeben"
                   Variant="Variant.Filled"
                   FullWidth/>
@@ -72,7 +70,7 @@
 
     [Parameter] public bool FormShowError { get; set; }
 
-    private bool IsError => FormShowError && (FormName == string.Empty || FormShop == string.Empty || FormItemNumber == string.Empty || FormPrice <= 0 || FormRoomName == string.Empty);
+    private bool IsError => FormShowError && (FormName == string.Empty || FormShop == string.Empty || FormItemNumber == string.Empty || FormPrice <= 0);
 
     [Parameter] public EventCallback OnReset { get; set; }
 

--- a/src/TuDa.CIMS.Web/Components/Dashboard/Dialogs/AssetItemForm.razor
+++ b/src/TuDa.CIMS.Web/Components/Dashboard/Dialogs/AssetItemForm.razor
@@ -5,7 +5,7 @@
 <MudForm>
     <MudTextField @bind-Value="FormName"
                   Label="Name"
-                  Error="@IsError"
+                  Error="@NameIsError"
                   ErrorText="Der Name muss eingegeben werden!"
                   Placeholder="Name eingeben"
                   Variant="Variant.Filled"
@@ -13,7 +13,7 @@
 
     <MudTextField @bind-Value="FormShop"
                   Label="Lieferant"
-                  Error="@IsError"
+                  Error="@ShopIsError"
                   ErrorText="Der Lieferant muss eingegeben werden!"
                   Placeholder="Shop eingeben"
                   Variant="Variant.Filled"
@@ -21,7 +21,7 @@
 
     <MudTextField @bind-Value="FormItemNumber"
                   Label="Produktnummer"
-                  Error="@IsError"
+                  Error="@ItemNumberIsError"
                   ErrorText="Die Produktnummer muss eingegeben werden!"
                   Placeholder="Produktnummer eingeben"
                   Variant="Variant.Filled"
@@ -35,7 +35,7 @@
 
     <MudNumericField @bind-Value="FormPrice"
                      Label="Preis"
-                     Error="@IsError"
+                     Error="@PriceIsError"
                      ErrorText="Der Preis muss eingegeben werden!"
                      Placeholder="Preis eingeben"
                      Variant="Variant.Filled"
@@ -70,7 +70,10 @@
 
     [Parameter] public bool FormShowError { get; set; }
 
-    private bool IsError => FormShowError && (FormName == string.Empty || FormShop == string.Empty || FormItemNumber == string.Empty || FormPrice <= 0);
+    private bool PriceIsError => FormShowError && FormPrice <= 0;
+    private bool NameIsError => FormShowError && FormName == string.Empty;
+    private bool ShopIsError => FormShowError && FormShop == string.Empty;
+    private bool ItemNumberIsError => FormShowError && FormItemNumber == string.Empty;
 
     [Parameter] public EventCallback OnReset { get; set; }
 

--- a/src/TuDa.CIMS.Web/Components/Dashboard/Dialogs/ChemicalItemForm.razor
+++ b/src/TuDa.CIMS.Web/Components/Dashboard/Dialogs/ChemicalItemForm.razor
@@ -30,12 +30,12 @@
                ErrorText="Preiseinheit fehlt!"
                Variant="Variant.Filled"
                FullWidth>
-        <MudSelectItem Value="MeasurementUnits.Unitless">-</MudSelectItem>
-        <MudSelectItem Value="MeasurementUnits.Gram">Gramm</MudSelectItem>
-        <MudSelectItem Value="MeasurementUnits.KiloGram">Kilogramm</MudSelectItem>
-        <MudSelectItem Value="MeasurementUnits.MilliLiter">Milliliter</MudSelectItem>
-        <MudSelectItem Value="MeasurementUnits.Liter">Liter</MudSelectItem>
-        <MudSelectItem Value="MeasurementUnits.Piece">Stück</MudSelectItem>
+        <MudSelectItem T="MeasurementUnits?" Value="null">-</MudSelectItem>
+        <MudSelectItem T="MeasurementUnits?" Value="MeasurementUnits.Gram">Gramm</MudSelectItem>
+        <MudSelectItem T="MeasurementUnits?" Value="MeasurementUnits.KiloGram">Kilogramm</MudSelectItem>
+        <MudSelectItem T="MeasurementUnits?" Value="MeasurementUnits.MilliLiter">Milliliter</MudSelectItem>
+        <MudSelectItem T="MeasurementUnits?" Value="MeasurementUnits.Liter">Liter</MudSelectItem>
+        <MudSelectItem T="MeasurementUnits?" Value="MeasurementUnits.Piece">Stück</MudSelectItem>
     </MudSelect>
 </MudForm>
 
@@ -44,7 +44,7 @@
     /// <summary>
     /// Input Fields
     /// </summary>
-    public MeasurementUnits FormPriceUnit { get; private set; }
+    public MeasurementUnits? FormPriceUnit { get; private set; }
     public string FormCas { get; private set; } = string.Empty;
     public string FormPurity { get; private set; } = string.Empty;
     public double FormBindingSize { get; private set; }
@@ -52,7 +52,7 @@
 
     [Parameter] public bool FormShowError { get; set; }
 
-    private bool IsError => FormPriceUnit == MeasurementUnits.Unitless && FormShowError;
+    private bool IsError => FormPriceUnit == null  && FormShowError;
 
 
     public void SetForm(Chemical item)

--- a/src/TuDa.CIMS.Web/Components/Dashboard/Dialogs/ChemicalItemForm.razor
+++ b/src/TuDa.CIMS.Web/Components/Dashboard/Dialogs/ChemicalItemForm.razor
@@ -7,23 +7,17 @@
 <MudForm>
     <MudTextField @bind-Value="FormCas"
                   Label="CAS"
-                  Error="@IsError"
-                  ErrorText="Die CAS muss eingegeben werden!"
                   Placeholder="CAS eingeben"
                   Variant="Variant.Filled"
                   FullWidth/>
 
     <MudTextField @bind-Value="FormPurity"
                   Label="Reinheit"
-                  Error="@IsError"
-                  ErrorText="Die Reinheit muss eingegeben werden!"
                   Placeholder="Reinheit eingeben"
                   Variant="Variant.Filled"
                   FullWidth/>
 
     <MudNumericField @bind-Value="FormBindingSize"
-                     Error="@IsError"
-                     ErrorText="Die Größe des Gebindes muss größer als 0 betragen!"
                      Label="Größe des Gebindes"
                      Placeholder="Gebindengröße eingeben"
                      Variant="Variant.Filled"
@@ -32,8 +26,11 @@
     <!-- MudSelect for selecting measurement unit -->
     <MudSelect @bind-Value="FormPriceUnit"
                Label="Preis Einheit wählen"
+               Error="@IsError"
+               ErrorText="Preiseinheit fehlt!"
                Variant="Variant.Filled"
                FullWidth>
+        <MudSelectItem Value="MeasurementUnits.Unitless">-</MudSelectItem>
         <MudSelectItem Value="MeasurementUnits.Gram">Gramm</MudSelectItem>
         <MudSelectItem Value="MeasurementUnits.KiloGram">Kilogramm</MudSelectItem>
         <MudSelectItem Value="MeasurementUnits.MilliLiter">Milliliter</MudSelectItem>
@@ -55,7 +52,7 @@
 
     [Parameter] public bool FormShowError { get; set; }
 
-    private bool IsError => FormShowError && (FormCas == string.Empty || FormPurity == string.Empty || FormBindingSize <= 0);
+    private bool IsError => FormPriceUnit == MeasurementUnits.Unitless && FormShowError;
 
 
     public void SetForm(Chemical item)

--- a/src/TuDa.CIMS.Web/Components/Dashboard/Dialogs/ConsumableItemForm.razor
+++ b/src/TuDa.CIMS.Web/Components/Dashboard/Dialogs/ConsumableItemForm.razor
@@ -4,16 +4,12 @@
 <MudForm>
     <MudTextField @bind-Value="FormManufacturer"
                   Label=Hersteller
-                  Error="@IsError"
-                  ErrorText="Der Hersteller muss eingegeben werden!"
                   Placeholder="Hersteller eingeben"
                   Variant="Variant.Filled"
                   FullWidth/>
 
     <MudTextField @bind-Value="FormSerialNumber"
                   Label="Seriennummer"
-                  Error="@IsError"
-                  ErrorText="Die Seriennummern muss eingegeben werden!"
                   Placeholder="Seriennummer eingeben"
                   Variant="Variant.Filled"
                   FullWidth/>
@@ -38,7 +34,7 @@
 
     [Parameter] public bool FormShowError { get; set; }
 
-    private bool IsError => FormShowError && (FormConsumableAmount <= 0 || FormManufacturer == string.Empty || FormSerialNumber == string.Empty);
+    private bool IsError => FormShowError && FormConsumableAmount <= 0;
 
 
     public void SetForm(Consumable item)

--- a/src/TuDa.CIMS.Web/Components/Dashboard/Dialogs/GasCylinderItemForm.razor
+++ b/src/TuDa.CIMS.Web/Components/Dashboard/Dialogs/GasCylinderItemForm.razor
@@ -22,12 +22,12 @@
                Label="Preis Einheit wählen"
                Variant="Variant.Filled"
                FullWidth>
-        <MudSelectItem Value="MeasurementUnits.Unitless">-</MudSelectItem>
-        <MudSelectItem Value="MeasurementUnits.Gram">Gramm</MudSelectItem>
-        <MudSelectItem Value="MeasurementUnits.KiloGram">Kilogramm</MudSelectItem>
-        <MudSelectItem Value="MeasurementUnits.MilliLiter">Milliliter</MudSelectItem>
-        <MudSelectItem Value="MeasurementUnits.Liter">Liter</MudSelectItem>
-        <MudSelectItem Value="MeasurementUnits.Piece">Stück</MudSelectItem>
+        <MudSelectItem T="MeasurementUnits?" Value="null">-</MudSelectItem>
+        <MudSelectItem T="MeasurementUnits?" Value="MeasurementUnits.Gram">Gramm</MudSelectItem>
+        <MudSelectItem T="MeasurementUnits?" Value="MeasurementUnits.KiloGram">Kilogramm</MudSelectItem>
+        <MudSelectItem T="MeasurementUnits?" Value="MeasurementUnits.MilliLiter">Milliliter</MudSelectItem>
+        <MudSelectItem T="MeasurementUnits?" Value="MeasurementUnits.Liter">Liter</MudSelectItem>
+        <MudSelectItem T="MeasurementUnits?" Value="MeasurementUnits.Piece">Stück</MudSelectItem>
     </MudSelect>
 
     <MudNumericField @bind-Value="FormVolume"
@@ -50,13 +50,13 @@
     /// </summary>
     public double FormVolume { get; private set; }
     public double FormPressure { get; private set; }
-    public MeasurementUnits FormPriceUnit { get;  set; }
+    public MeasurementUnits? FormPriceUnit { get;  set; }
     public string FormCas { get;  set; } = string.Empty;
     public string FormPurity { get;  set; } = string.Empty;
 
     [Parameter] public bool FormShowError { get; set; }
 
-    private bool IsError => FormPriceUnit == MeasurementUnits.Unitless && FormShowError;
+    private bool IsError => FormPriceUnit == null && FormShowError;
 
     public void SetForm(GasCylinder item)
     {

--- a/src/TuDa.CIMS.Web/Components/Dashboard/Dialogs/GasCylinderItemForm.razor
+++ b/src/TuDa.CIMS.Web/Components/Dashboard/Dialogs/GasCylinderItemForm.razor
@@ -5,25 +5,24 @@
 <MudForm>
     <MudTextField @bind-Value="FormCas"
                   Label="CAS"
-                  Error="@IsError"
-                  ErrorText="Die CAS muss eingegeben werden!"
                   Placeholder="CAS eingeben"
                   Variant="Variant.Filled"
                   FullWidth/>
 
     <MudTextField @bind-Value="FormPurity"
                   Label="Reinheit"
-                  Error="@IsError"
-                  ErrorText="Die Reinheit muss eingegeben werden!"
                   Placeholder="Reinheit eingeben"
                   Variant="Variant.Filled"
                   FullWidth/>
 
     <!-- MudSelect for selecting measurement unit -->
     <MudSelect @bind-Value="FormPriceUnit"
+               Error="@IsError"
+               ErrorText="Preiseinheit fehlt!"
                Label="Preis Einheit wählen"
                Variant="Variant.Filled"
                FullWidth>
+        <MudSelectItem Value="MeasurementUnits.Unitless">-</MudSelectItem>
         <MudSelectItem Value="MeasurementUnits.Gram">Gramm</MudSelectItem>
         <MudSelectItem Value="MeasurementUnits.KiloGram">Kilogramm</MudSelectItem>
         <MudSelectItem Value="MeasurementUnits.MilliLiter">Milliliter</MudSelectItem>
@@ -33,16 +32,12 @@
 
     <MudNumericField @bind-Value="FormVolume"
                      Label="Volume"
-                     Error="@IsError"
-                     ErrorText="Das Volumen muss größer als 0 betragen!"
                      Placeholder="Volumen eingeben"
                      Variant="Variant.Filled"
                      FullWidth/>
 
     <MudNumericField @bind-Value="FormPressure"
                      Label="Pressure"
-                     Error="@IsError"
-                     ErrorText="Der Druck muss größer als 0 betragen!"
                      Placeholder="Druck eingeben"
                      Variant="Variant.Filled"
                      FullWidth/>
@@ -61,8 +56,7 @@
 
     [Parameter] public bool FormShowError { get; set; }
 
-    private bool IsError => FormShowError && (FormVolume <= 0 || FormPressure <= 0 || FormCas == string.Empty
-                                              || FormPurity == string.Empty);
+    private bool IsError => FormPriceUnit == MeasurementUnits.Unitless && FormShowError;
 
     public void SetForm(GasCylinder item)
     {


### PR DESCRIPTION
added a default value null to the MudSelect, in which you can choose the price unit for an product.

This PR should also show separate errors when the Input is missing and not all of them.