### PR TITLE
`PurchaseInformationPopup`: Use correct amount of decimal digits

### DIFF
--- a/src/TuDa.CIMS.Web/Components/PurchaseInformation/PurchaseInformationPurchaseEntryList.razor
+++ b/src/TuDa.CIMS.Web/Components/PurchaseInformation/PurchaseInformationPurchaseEntryList.razor
@@ -1,3 +1,4 @@
+@using System.Globalization
 @using TuDa.CIMS.Shared.Dtos.Responses
 @using TuDa.CIMS.Shared.Entities
 @using TuDa.CIMS.Shared.Entities.Enums
@@ -61,6 +62,10 @@
             Substance substance => substance.PriceUnit.ToAbbreviation(),
             _ => "Stück"
         };
-        return $"{purchaseEntry.Amount:F} {temp}";
+        var culture = new CultureInfo("de-DE");
+        var amountString = temp == "Stück"
+            ? purchaseEntry.Amount.ToString("0", culture)
+            : purchaseEntry.Amount.ToString("0.00", culture);
+        return $"{amountString} {temp}";
     }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f6f917b6-b336-4d20-8fa6-ea76bcf520de)
