### PR TITLE
Correctly recognize amount of Consumables in ShoppingCart

### DIFF
--- a/src/TuDa.CIMS.Web/Components/Pages/InvalidatePurchasePage.razor.cs
+++ b/src/TuDa.CIMS.Web/Components/Pages/InvalidatePurchasePage.razor.cs
@@ -20,11 +20,6 @@ public class InvalidatePurchasePage : ShoppingCartPage
     private readonly ISnackbar _snackbar;
     private readonly NavigationManager _navigationManager;
 
-    /// <summary>
-    /// This saves the state of touched consumables.
-    /// </summary>
-    private readonly Dictionary<Guid, int> _touchedConsumables = [];
-
     public InvalidatePurchasePage(
         IDialogService dialogService,
         IPurchaseApi purchaseApi,
@@ -89,38 +84,6 @@ public class InvalidatePurchasePage : ShoppingCartPage
             }
 
             _navigationManager.NavigateTo("/");
-        }
-    }
-
-    protected override void AdaptAmountOfConsumableIfNeeded(AssetItem assetItem)
-    {
-        if (
-            assetItem is Consumable consumable
-            && Purchase.Entries.All(entry => entry.AssetItem.Id != consumable.Id)
-            && _touchedConsumables.Any(pair => pair.Key == consumable.Id)
-        )
-        {
-            consumable.Amount += _touchedConsumables[consumable.Id];
-        }
-        else
-        {
-            base.AdaptAmountOfConsumableIfNeeded(assetItem);
-        }
-    }
-
-    protected override void AdaptAmountOfAllConsumablesByAssetItemId(
-        Consumable consumable,
-        int amount
-    )
-    {
-        base.AdaptAmountOfAllConsumablesByAssetItemId(consumable, amount);
-        if (_touchedConsumables.Any(pair => pair.Key == consumable.Id))
-        {
-            _touchedConsumables[consumable.Id] -= amount;
-        }
-        else
-        {
-            _touchedConsumables.Add(consumable.Id, consumable.Amount);
         }
     }
 }

--- a/src/TuDa.CIMS.Web/Components/Pages/InvalidatePurchasePage.razor.cs
+++ b/src/TuDa.CIMS.Web/Components/Pages/InvalidatePurchasePage.razor.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
 using MudBlazor;
+using TuDa.CIMS.Shared.Entities;
 using TuDa.CIMS.Shared.Extensions;
 using TuDa.CIMS.Web.Services;
 
@@ -8,14 +9,21 @@ namespace TuDa.CIMS.Web.Components.Pages;
 [Route("/shop/{WorkingGroupId:guid}/{PurchaseId:guid}")]
 public class InvalidatePurchasePage : ShoppingCartPage
 {
-    [Parameter] public Guid WorkingGroupId { get; set; }
+    [Parameter]
+    public Guid WorkingGroupId { get; set; }
 
-    [Parameter] public Guid PurchaseId { get; set; }
+    [Parameter]
+    public Guid PurchaseId { get; set; }
 
     private readonly IDialogService _dialogService;
     private readonly IPurchaseApi _purchaseApi;
     private readonly ISnackbar _snackbar;
     private readonly NavigationManager _navigationManager;
+
+    /// <summary>
+    /// This saves the state of touched consumables.
+    /// </summary>
+    private readonly Dictionary<Guid, int> _touchedConsumables = [];
 
     public InvalidatePurchasePage(
         IDialogService dialogService,
@@ -65,7 +73,10 @@ public class InvalidatePurchasePage : ShoppingCartPage
             var success = await _purchaseApi.InvalidateAsync(
                 WorkingGroupId,
                 PurchaseId,
-                Purchase.ToCreateDto() with { Signature = signingResult }
+                Purchase.ToCreateDto() with
+                {
+                    Signature = signingResult,
+                }
             );
 
             if (success.IsError)
@@ -78,6 +89,38 @@ public class InvalidatePurchasePage : ShoppingCartPage
             }
 
             _navigationManager.NavigateTo("/");
+        }
+    }
+
+    protected override void AdaptAmountOfConsumableIfNeeded(AssetItem assetItem)
+    {
+        if (
+            assetItem is Consumable consumable
+            && Purchase.Entries.All(entry => entry.AssetItem.Id != consumable.Id)
+            && _touchedConsumables.Any(pair => pair.Key == consumable.Id)
+        )
+        {
+            consumable.Amount += _touchedConsumables[consumable.Id];
+        }
+        else
+        {
+            base.AdaptAmountOfConsumableIfNeeded(assetItem);
+        }
+    }
+
+    protected override void AdaptAmountOfAllConsumablesByAssetItemId(
+        Consumable consumable,
+        int amount
+    )
+    {
+        base.AdaptAmountOfAllConsumablesByAssetItemId(consumable, amount);
+        if (_touchedConsumables.Any(pair => pair.Key == consumable.Id))
+        {
+            _touchedConsumables[consumable.Id] -= amount;
+        }
+        else
+        {
+            _touchedConsumables.Add(consumable.Id, consumable.Amount);
         }
     }
 }

--- a/src/TuDa.CIMS.Web/Components/Pages/ShoppingCartPage.razor
+++ b/src/TuDa.CIMS.Web/Components/Pages/ShoppingCartPage.razor
@@ -10,7 +10,7 @@
 
         <!-- Purchase Entry List -->
         <MudItem xs="12" sm="12" md="12">
-            <PurchaseEntryList Purchase="@Purchase" AssetItemDeleted="@(_ => StateHasChanged())"/>
+            <PurchaseEntryList Purchase="@Purchase" PurchaseEntryDeleted="@RemovePurchaseEntry"/>
         </MudItem>
 
         <!-- Shopping Cart Footer  -->

--- a/src/TuDa.CIMS.Web/Components/Pages/ShoppingCartPage.razor.cs
+++ b/src/TuDa.CIMS.Web/Components/Pages/ShoppingCartPage.razor.cs
@@ -133,7 +133,7 @@ public partial class ShoppingCartPage
         return signResult?.Data as byte[];
     }
 
-    private void AdaptAmountOfConsumableIfNeeded(AssetItem assetItem)
+    protected virtual void AdaptAmountOfConsumableIfNeeded(AssetItem assetItem)
     {
         if (assetItem is not Consumable consumable)
             return;
@@ -152,11 +152,6 @@ public partial class ShoppingCartPage
 
     private void AddProductEntry(double amount, AssetItem product)
     {
-        if (product is Consumable consumable)
-        {
-            product = AdaptAmountOfAllConsumablesByAssetItemId(consumable, (int)amount);
-        }
-
         Purchase.Entries.Add(
             new PurchaseEntry()
             {
@@ -165,19 +160,26 @@ public partial class ShoppingCartPage
                 PricePerItem = product.Price,
             }
         );
+        if (product is Consumable consumable)
+        {
+            AdaptAmountOfAllConsumablesByAssetItemId(consumable, (int)amount);
+        }
     }
 
     private void RemovePurchaseEntry(PurchaseEntry entry)
     {
         if (entry.AssetItem is Consumable consumable)
         {
-            AdaptAmountOfAllConsumablesByAssetItemId(consumable, (int)entry.Amount);
+            AdaptAmountOfAllConsumablesByAssetItemId(consumable, -(int)entry.Amount);
         }
         Purchase.Entries.Remove(entry);
         StateHasChanged();
     }
 
-    private Consumable AdaptAmountOfAllConsumablesByAssetItemId(Consumable consumable, int amount)
+    protected virtual void AdaptAmountOfAllConsumablesByAssetItemId(
+        Consumable consumable,
+        int amount
+    )
     {
         var sameConsumables = Purchase
             .Entries.Where(entry => entry.AssetItem.Id == consumable.Id)
@@ -187,10 +189,5 @@ public partial class ShoppingCartPage
         {
             c!.Amount -= amount;
         }
-
-        return consumable with
-        {
-            Amount = consumable.Amount - amount,
-        };
     }
 }

--- a/src/TuDa.CIMS.Web/Components/Pages/ShoppingCartPage.razor.cs
+++ b/src/TuDa.CIMS.Web/Components/Pages/ShoppingCartPage.razor.cs
@@ -184,22 +184,13 @@ public partial class ShoppingCartPage
         int amountToSubtract
     )
     {
-        var sameConsumables = Purchase
-            .Entries.Where(entry => entry.AssetItem.Id == consumable.Id)
-            .Select(entry => entry.AssetItem as Consumable!);
-
-        foreach (var c in sameConsumables)
-        {
-            c!.Amount -= amountToSubtract;
-        }
-
         if (_touchedConsumables.Any(pair => pair.Key == consumable.Id))
         {
             _touchedConsumables[consumable.Id] -= amountToSubtract;
         }
         else
         {
-            _touchedConsumables.Add(consumable.Id, consumable.Amount);
+            _touchedConsumables.Add(consumable.Id, consumable.Amount - amountToSubtract);
         }
     }
 }

--- a/src/TuDa.CIMS.Web/Components/ShoppingCart/PurchaseEntryList.razor.cs
+++ b/src/TuDa.CIMS.Web/Components/ShoppingCart/PurchaseEntryList.razor.cs
@@ -18,7 +18,7 @@ public partial class PurchaseEntryList : ComponentBase
     public required PurchaseResponseDto Purchase { get; set; }
 
     [Parameter]
-    public EventCallback<AssetItem> AssetItemDeleted { get; set; }
+    public EventCallback<PurchaseEntry> PurchaseEntryDeleted { get; set; }
 
     private readonly IDialogService _dialogService;
 
@@ -47,8 +47,7 @@ public partial class PurchaseEntryList : ComponentBase
 
         if (await _dialogService.ShowMessageBox(messageBox) ?? false)
         {
-            Purchase.Entries.Remove(entry);
-            await AssetItemDeleted.InvokeAsync();
+            await PurchaseEntryDeleted.InvokeAsync(entry);
         }
     }
 }


### PR DESCRIPTION
This allows to correctly recognize the used amount of Consumables in the `ShoppingCart`.

This now works for normal submitting and invalidation.

## Example

### Standard Submission

If a consumable has only 3 items remaining and the user purchases 2, they can only buy 1 more in the same transaction.

### Invalidation

Similar to standard submission, but additionally, if an item is out of stock and the user removes a previous entry, the removed quantity is restored, allowing the user to add the item again.