### PR TITLE
Indicator for invalidated Purchases on WorkingGroupPage

### DIFF
--- a/src/TuDa.CIMS.Web/Components/WorkingGroupPage/WorkingGroupPurchaseList.razor
+++ b/src/TuDa.CIMS.Web/Components/WorkingGroupPage/WorkingGroupPurchaseList.razor
@@ -9,10 +9,12 @@
         <Columns>
             <PropertyColumn
                 Property="@(p => FormatCompletionDate(p))"
-                Title="Datum"/>
+                Title="Datum"
+                CellStyleFunc="@(p => GetTextStyle(p))"/>
             <PropertyColumn
                 Property="@(p => p.TotalPrice.ToString("C", CultureInfo.GetCultureInfo("de-DE")))"
-                Title="Preis"/>
+                Title="Preis"
+                CellStyleFunc="@(p => GetTextStyle(p))"/>
             <TemplateColumn CellClass="d-flex justify-end">
                 <CellTemplate>
                     <MudIconButton Size="@Size.Small"

--- a/src/TuDa.CIMS.Web/Components/WorkingGroupPage/WorkingGroupPurchaseList.razor.cs
+++ b/src/TuDa.CIMS.Web/Components/WorkingGroupPage/WorkingGroupPurchaseList.razor.cs
@@ -54,7 +54,7 @@ public partial class WorkingGroupPurchaseList
     }
 
     private static string GetTextStyle(PurchaseResponseDto purchase) =>
-        purchase.Invalidated ? "text-decoration: line-through;" : "";
+        purchase.Invalidated ? $"color: {Colors.Red.Default}; text-decoration: line-through;" : "";
 
     private async Task NavigateToPurchase(PurchaseResponseDto purchase)
     {

--- a/src/TuDa.CIMS.Web/Components/WorkingGroupPage/WorkingGroupPurchaseList.razor.cs
+++ b/src/TuDa.CIMS.Web/Components/WorkingGroupPage/WorkingGroupPurchaseList.razor.cs
@@ -53,6 +53,9 @@ public partial class WorkingGroupPurchaseList
             : "";
     }
 
+    private static string GetTextStyle(PurchaseResponseDto purchase) =>
+        purchase.Invalidated ? "text-decoration: line-through;" : "";
+
     private async Task NavigateToPurchase(PurchaseResponseDto purchase)
     {
         var options = new DialogOptions { CloseOnEscapeKey = true };


### PR DESCRIPTION
Invalidated purchases are now strike-through to indicated their current state.

Do you think the strike-through is enough, or should we also add the red color?
## State
![image](https://github.com/user-attachments/assets/8bfe40b6-d42b-48ab-bec2-9269dda7122f)