### PR TITLE
Improve Input Handling and Submission in GenericInputPopUp

### DIFF
--- a/src/TuDa.CIMS.Web/Components/WorkingGroupPage/GenericInputPopUp.razor.cs
+++ b/src/TuDa.CIMS.Web/Components/WorkingGroupPage/GenericInputPopUp.razor.cs
@@ -36,8 +36,9 @@ public partial class GenericInputPopUp : ComponentBase
 
     private MudForm _form { get; set; } = null!;
 
-    private void Submit()
+    private async Task Submit()
     {
+        await _form.Validate();
         if (_form.IsValid)
         {
             MudDialog.Close(DialogResult.Ok(Fields.Select(f => f.Value).ToList()));

--- a/src/TuDa.CIMS.Web/Components/WorkingGroupPage/GenericInputPopUp.razor.cs
+++ b/src/TuDa.CIMS.Web/Components/WorkingGroupPage/GenericInputPopUp.razor.cs
@@ -5,14 +5,14 @@ namespace TuDa.CIMS.Web.Components.WorkingGroupPage;
 
 public record GenericInputField
 {
-    public string Label { get; init; }
-    public string? Value { get; set; }
-    public bool Required { get; init; } = false;
+    public string Label { get; }
+    public string Value { get; set; } = string.Empty;
+    public bool Required { get; }
 
     public GenericInputField(string label, string? value = null, bool required = false)
     {
         Label = label;
-        Value = value;
+        Value = value ?? string.Empty;
         Required = required;
     }
 


### PR DESCRIPTION
This pull request includes changes to the `GenericInputPopUp` component in the `src/TuDa.CIMS.Web/Components/WorkingGroupPage/GenericInputPopUp.razor.cs` file. The changes improve the handling of input fields and the submission process.

This fixes #323 

Improvements to input field handling:

* `GenericInputField` record: Modified the `Label` and `Required` properties to be read-only and set default values for the `Value` property to an empty string. This ensures that the `Value` property is never null.

Enhancements to submission process:

* `Submit` method: Changed the method to be asynchronous and added a call to `_form.Validate()` to ensure the form is validated before checking if it is valid and closing the dialog with the input values.