### PR TITLE
Use semantic versioning for Docker container tags

### DIFF
--- a/.github/workflows/cd-build-and-release.yml
+++ b/.github/workflows/cd-build-and-release.yml
@@ -28,12 +28,23 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Extract tag information
-        id: tag
+      - name: Extract release information
+        id: release
         run: |
           PRERELEASE=${{ github.event.release.prerelease && 'true' || 'false' }}
           echo "prerelease=$PRERELEASE" >> $GITHUB_OUTPUT
-          echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+      - name: Extract semantic version components
+        id: semver
+        run: |
+          semver_regex="^v?([0-9]+)\.([0-9]+)\.([0-9]+)"
+          if [[ "${{ github.event.release.tag_name }}" =~ $semver_regex ]]; then
+            echo "major=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+            echo "minor=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
+            echo "patch=${BASH_REMATCH[3]}" >> $GITHUB_OUTPUT
+          else
+            echo "Invalid semantic version tag: ${{ github.event.release.tag_name }}"
+            exit 1
+          fi
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -48,8 +59,10 @@ jobs:
           platforms: linux/arm64,linux/amd64
           push: true
           tags: |
-            ghcr.io/projectcims/cims-api:${{ steps.tag.outputs.prerelease == 'true' && 'prerelease' || 'latest' }}
-            ghcr.io/projectcims/cims-api:${{ steps.tag.outputs.tag }}
+            ghcr.io/projectcims/cims-api:${{ steps.release.outputs.prerelease == 'true' && 'prerelease' || 'latest' }}
+            ghcr.io/projectcims/cims-api:"${{ steps.semver.outputs.major }}"
+            ghcr.io/projectcims/cims-api:"${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}"
+            ghcr.io/projectcims/cims-api:"${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}.${{ steps.semver.outputs.patch }}"
       - name: Build and push Web Docker image
         uses: docker/build-push-action@v6
         with:
@@ -58,5 +71,7 @@ jobs:
           platforms: linux/arm64,linux/amd64
           push: true
           tags: |
-            ghcr.io/projectcims/cims-web:${{ steps.tag.outputs.prerelease == 'true' && 'prerelease' || 'latest' }}
-            ghcr.io/projectcims/cims-web:${{ steps.tag.outputs.tag }}
+            ghcr.io/projectcims/cims-web:${{ steps.release.outputs.prerelease == 'true' && 'prerelease' || 'latest' }}
+            ghcr.io/projectcims/cims-web:"${{ steps.semver.outputs.major }}"
+            ghcr.io/projectcims/cims-web:"${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}"
+            ghcr.io/projectcims/cims-web:"${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}.${{ steps.semver.outputs.patch }}"

--- a/.github/workflows/cd-build-and-release.yml
+++ b/.github/workflows/cd-build-and-release.yml
@@ -20,6 +20,7 @@ jobs:
         run: dotnet build --no-restore
       - name: Test
         run: dotnet test --no-build --verbosity normal
+
   build-and-push-image:
     runs-on: ubuntu-latest
     needs: run-tests
@@ -28,30 +29,21 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Extract release information
-        id: release
-        run: |
-          PRERELEASE=${{ github.event.release.prerelease && 'true' || 'false' }}
-          echo "prerelease=$PRERELEASE" >> $GITHUB_OUTPUT
-      - name: Extract semantic version components
+      - name: Parse semantic version
         id: semver
-        run: |
-          semver_regex="^v?([0-9]+)\.([0-9]+)\.([0-9]+)"
-          if [[ "${{ github.event.release.tag_name }}" =~ $semver_regex ]]; then
-            echo "major=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
-            echo "minor=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
-            echo "patch=${BASH_REMATCH[3]}" >> $GITHUB_OUTPUT
-          else
-            echo "Invalid semantic version tag: ${{ github.event.release.tag_name }}"
-            exit 1
-          fi
+        uses: booxmedialtd/ws-action-parse-semver@v1
+        with:
+          input_string: ${{ github.event.release.tag_name }}
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push API Docker image
+
+      # Stable release builds (non-prerelease)
+      - name: Build and push API Docker image (stable)
+        if: ${{ !github.event.release.prerelease }}
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -59,11 +51,13 @@ jobs:
           platforms: linux/arm64,linux/amd64
           push: true
           tags: |
-            ghcr.io/projectcims/cims-api:${{ steps.release.outputs.prerelease == 'true' && 'prerelease' || 'latest' }}
-            ghcr.io/projectcims/cims-api:"${{ steps.semver.outputs.major }}"
-            ghcr.io/projectcims/cims-api:"${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}"
-            ghcr.io/projectcims/cims-api:"${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}.${{ steps.semver.outputs.patch }}"
-      - name: Build and push Web Docker image
+            ghcr.io/projectcims/cims-api:latest
+            ghcr.io/projectcims/cims-api:${{ steps.semver.outputs.major }}
+            ghcr.io/projectcims/cims-api:${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}
+            ghcr.io/projectcims/cims-api:${{ steps.semver.outputs.fullversion }}
+
+      - name: Build and push Web Docker image (stable)
+        if: ${{ !github.event.release.prerelease }}
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -71,7 +65,32 @@ jobs:
           platforms: linux/arm64,linux/amd64
           push: true
           tags: |
-            ghcr.io/projectcims/cims-web:${{ steps.release.outputs.prerelease == 'true' && 'prerelease' || 'latest' }}
-            ghcr.io/projectcims/cims-web:"${{ steps.semver.outputs.major }}"
-            ghcr.io/projectcims/cims-web:"${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}"
-            ghcr.io/projectcims/cims-web:"${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}.${{ steps.semver.outputs.patch }}"
+            ghcr.io/projectcims/cims-web:latest
+            ghcr.io/projectcims/cims-web:${{ steps.semver.outputs.major }}
+            ghcr.io/projectcims/cims-web:${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}
+            ghcr.io/projectcims/cims-web:${{ steps.semver.outputs.fullversion }}
+
+      # Prerelease builds
+      - name: Build and push API Docker image (prerelease)
+        if: ${{ github.event.release.prerelease }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./src/TuDa.CIMS.Api/Dockerfile
+          platforms: linux/arm64,linux/amd64
+          push: true
+          tags: |
+            ghcr.io/projectcims/cims-api:${{ steps.semver.outputs.prerelease }}
+            ghcr.io/projectcims/cims-api:${{ steps.semver.outputs.fullversion }}
+
+      - name: Build and push Web Docker image (prerelease)
+        if: ${{ github.event.release.prerelease }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./src/TuDa.CIMS.Web/Dockerfile
+          platforms: linux/arm64,linux/amd64
+          push: true
+          tags: |
+            ghcr.io/projectcims/cims-web:${{ steps.semver.outputs.prerelease }}
+            ghcr.io/projectcims/cims-web:${{ steps.semver.outputs.fullversion }}


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/cd-build-and-release.yml` file to improve the extraction and usage of semantic version components for Docker image tags.

Improvements to semantic versioning:

* Changed the step name from "Extract tag information" to "Extract release information" and added a new step to extract semantic version components from the release tag. (`.github/workflows/cd-build-and-release.yml`, [.github/workflows/cd-build-and-release.ymlL31-R47](diffhunk://#diff-73e6cd7dc4d3f47c15d8ab9de035bf4e313ab8e0fdde481140a15fdbd2e682ebL31-R47))
* Updated Docker image tags to use semantic version components (`major`, `minor`, `patch`) instead of the full tag name. (`.github/workflows/cd-build-and-release.yml`, [[1]](diffhunk://#diff-73e6cd7dc4d3f47c15d8ab9de035bf4e313ab8e0fdde481140a15fdbd2e682ebL51-R65) [[2]](diffhunk://#diff-73e6cd7dc4d3f47c15d8ab9de035bf4e313ab8e0fdde481140a15fdbd2e682ebL61-R77)