### PR TITLE
Split docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ It is a project developed by IT students as part of their **Bachelor Praktikum**
 > you can specify the version in the `docker-compose.yml` file.
 > Change `:latest` to the desired version in the `image` field.
 
-### Using Docker Locally
+### Build Docker image locally
 
 > **Requires docker to be installed and the daemon to be running**
 
@@ -70,7 +70,7 @@ It is a project developed by IT students as part of their **Bachelor Praktikum**
 2. **Build and run with Docker Compose**:
 
     ```sh
-    docker compose up --build -d
+    docker compose -f ./docker-compose.dev.yml up --build
     ```
 
 3. **The `API`, `Web`, and `DB` containers should now be running**

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ It is a project developed by IT students as part of their **Bachelor Praktikum**
 2. **Build and run with Docker Compose**:
 
     ```sh
-    docker compose -f ./docker-compose.dev.yml up --build
+    docker compose -f ./docker-compose.dev.yml up --build -d
     ```
 
 3. **The `API`, `Web`, and `DB` containers should now be running**

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,38 @@
+﻿services:
+  cims-web:
+    image: ghcr.io/projectcims/cims-web:dev
+    build:
+      context: .
+      dockerfile: src/TuDa.CIMS.Web/Dockerfile
+    depends_on:
+      - cims-api
+    environment:
+      - Api__BaseUrl=http://cims-api:8080
+    ports:
+      - "80:8080"
+
+  cims-api:
+    image: ghcr.io/projectcims/cims-api:dev
+    build:
+      context: .
+      dockerfile: src/TuDa.CIMS.Api/Dockerfile
+    depends_on:
+      - cims-db
+    environment:
+      - ConnectionStrings__CIMS=Host=cims-db;Port=5432;Database=CIMS;Username=postgres;Password=postgres
+    ports:
+      - "8080:8080"
+
+  cims-db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: CIMS
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,6 @@
 ﻿services:
   cims-web:
     image: ghcr.io/projectcims/cims-web:latest
-    build:
-      context: .
-      dockerfile: src/TuDa.CIMS.Web/Dockerfile
     depends_on:
       - cims-api
     environment:
@@ -13,9 +10,6 @@
 
   cims-api:
     image: ghcr.io/projectcims/cims-api:latest
-    build:
-      context: .
-      dockerfile: src/TuDa.CIMS.Api/Dockerfile
     depends_on:
       - cims-db
     environment:


### PR DESCRIPTION
This pull request includes changes to the `docker-compose` files to add a development environment setup and simplify the production configuration. The most important changes include adding a new `docker-compose.dev.yml` file for the development environment and removing build instructions from the `docker-compose.yml` file for the production environment.

Development environment setup:

* [`docker-compose.dev.yml`](diffhunk://#diff-9542f82d64bbeebd91f6236324bfe199e9657e2cb1fd9779d5d6dcdcf9cd4de1R1-R38): Added a new `docker-compose` file to define services for the development environment, including `cims-web`, `cims-api`, and `cims-db`, along with their respective dependencies, environment variables, and ports.

Production configuration simplification:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L4-L6): Removed the build instructions for `cims-web` and `cims-api` services to streamline the production configuration. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L4-L6) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L16-L18)