### PR TITLE
Adjust AssetItemImporter scripts for GitHub registry prebuild container

### DIFF
--- a/utils/TuDa.CIMS.AssetItemImporter/README.md
+++ b/utils/TuDa.CIMS.AssetItemImporter/README.md
@@ -27,10 +27,10 @@
 
 ### Container usage
 
-- Default (uses registry image): `./utils/TuDa.CIMS.AssetItemImporter/run-container-attach.sh /your/host/dir`
+- Default (uses registry image `ghcr.io/projectcims/cims-asset-item-importer:latest`): `./utils/TuDa.CIMS.AssetItemImporter/run-container-attach.sh /your/host/dir`
 - Use local image (build if needed): `./utils/TuDa.CIMS.AssetItemImporter/run-container-attach.sh --local /your/host/dir`
 - Force rebuild local image: `./utils/TuDa.CIMS.AssetItemImporter/run-container-attach.sh --local --rebuild /your/host/dir`
-- Manually build: `docker build -t cims-asset-importer:local -f utils/TuDa.CIMS.AssetItemImporter/Dockerfile .`
+- Manually build: `docker build -t cims-asset-item-importer:local -f utils/TuDa.CIMS.AssetItemImporter/Dockerfile .`
 - Inside container, run: `asset-importer check <type> "/work/file.xlsx"`
 - Or import: `asset-importer import <type> "/work/file.xlsx" <api-url>`
 

--- a/utils/TuDa.CIMS.AssetItemImporter/README.md
+++ b/utils/TuDa.CIMS.AssetItemImporter/README.md
@@ -27,8 +27,10 @@
 
 ### Container usage
 
-- Build image: `docker build -t cims-asset-importer:local -f utils/TuDa.CIMS.AssetItemImporter/Dockerfile .`
-- Attach shell: `./utils/TuDa.CIMS.AssetItemImporter/run-container-attach.sh /your/host/dir [--rebuild]`
+- Default (uses registry image): `./utils/TuDa.CIMS.AssetItemImporter/run-container-attach.sh /your/host/dir`
+- Use local image (build if needed): `./utils/TuDa.CIMS.AssetItemImporter/run-container-attach.sh --local /your/host/dir`
+- Force rebuild local image: `./utils/TuDa.CIMS.AssetItemImporter/run-container-attach.sh --local --rebuild /your/host/dir`
+- Manually build: `docker build -t cims-asset-importer:local -f utils/TuDa.CIMS.AssetItemImporter/Dockerfile .`
 - Inside container, run: `asset-importer check <type> "/work/file.xlsx"`
 - Or import: `asset-importer import <type> "/work/file.xlsx" <api-url>`
 

--- a/utils/TuDa.CIMS.AssetItemImporter/run-container-attach.ps1
+++ b/utils/TuDa.CIMS.AssetItemImporter/run-container-attach.ps1
@@ -2,13 +2,15 @@
 #requires -Version 5
 
 param(
-  [Parameter(Mandatory = $true, Position = 0)]
+  [Parameter(Position = 0)]
   [string]$Workdir,
 
   [Parameter(ValueFromRemainingArguments = $true)]
   [string[]]$DockerArgs,
 
-  [switch]$Rebuild
+  [switch]$Local,
+  [switch]$Rebuild,
+  [string]$Image
 )
 
 $ErrorActionPreference = 'Stop'
@@ -21,7 +23,9 @@ if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $RepoRoot = (Resolve-Path (Join-Path $ScriptDir '..\..')).Path
 
-$Image = if ($env:IMAGE) { $env:IMAGE } else { 'cims-asset-importer:local' }
+# Default to registry image to match docker-compose; allow override via param or env.
+$DefaultRegistryImage = 'ghcr.io/projectcims/cims-asset-importer:latest'
+$Image = if ($PSBoundParameters.ContainsKey('Image')) { $Image } elseif ($env:IMAGE) { $env:IMAGE } else { $DefaultRegistryImage }
 
 # Default Dockerfile/Context anchored at repo root; allow env overrides
 $Dockerfile = if ($env:DOCKERFILE) { $env:DOCKERFILE } else { Join-Path $RepoRoot 'utils\TuDa.CIMS.AssetItemImporter\Dockerfile' }
@@ -30,30 +34,44 @@ if (-not [System.IO.Path]::IsPathRooted($Dockerfile)) { $Dockerfile = (Resolve-P
 $Context = if ($env:CONTEXT) { $env:CONTEXT } else { $RepoRoot }
 if (-not [System.IO.Path]::IsPathRooted($Context)) { $Context = (Resolve-Path (Join-Path (Get-Location) $Context)).Path } else { $Context = (Resolve-Path $Context).Path }
 
-if (-not (Test-Path -LiteralPath $Workdir)) {
-  Write-Error "Workdir does not exist: $Workdir"
+# If Workdir not passed positionally, try to consume the first remaining DockerArgs as Workdir for convenience
+if (-not $Workdir -and $DockerArgs -and $DockerArgs.Length -gt 0) {
+  $Workdir = $DockerArgs[0]
+  $DockerArgs = $DockerArgs[1..($DockerArgs.Length-1)]
 }
+
+if (-not $Workdir) { throw "Usage: run-container-attach.ps1 [-Local] [-Rebuild] [-Image <tag>] <host-workdir> [extra docker args]" }
+if (-not (Test-Path -LiteralPath $Workdir)) { throw "Workdir does not exist: $Workdir" }
 
 $FullPath = [System.IO.Path]::GetFullPath($Workdir)
 $mount = ($FullPath + ':/work')
 
-# Inspect image; if missing, build it
-Write-Host "Using Dockerfile: $Dockerfile"
-Write-Host "Using context:     $Context"
+# Local build path: only build if -Local is specified
+if ($Local) {
+  if (-not $PSBoundParameters.ContainsKey('Image') -and -not $env:IMAGE -and $Image -eq $DefaultRegistryImage) {
+    # If user didn't provide an image explicitly, use a sensible local default
+    $Image = 'cims-asset-importer:local'
+  }
 
-& docker image inspect $Image *> $null
-if ($LASTEXITCODE -ne 0) {
-  Write-Host "Image '$Image' not found locally. Building..."
-  & docker build -t $Image -f $Dockerfile $Context
+  Write-Host "Using Dockerfile: $Dockerfile"
+  Write-Host "Using context:     $Context"
+
+  & docker image inspect $Image *> $null
   if ($LASTEXITCODE -ne 0) {
-    throw "Docker build failed. See output above. Dockerfile='$Dockerfile' Context='$Context'"
+    Write-Host "Local image '$Image' not found. Building..."
+    & docker build -t $Image -f $Dockerfile $Context
+    if ($LASTEXITCODE -ne 0) {
+      throw "Docker build failed. See output above. Dockerfile='$Dockerfile' Context='$Context'"
+    }
+  } elseif ($Rebuild -or ($env:REBUILD -eq '1')) {
+    Write-Host "Rebuilding local image '$Image' ..."
+    & docker build --no-cache -t $Image -f $Dockerfile $Context
+    if ($LASTEXITCODE -ne 0) {
+      throw "Docker rebuild failed. See output above. Dockerfile='$Dockerfile' Context='$Context'"
+    }
   }
 } elseif ($Rebuild -or ($env:REBUILD -eq '1')) {
-  Write-Host "Rebuilding image '$Image' ..."
-  & docker build --no-cache -t $Image -f $Dockerfile $Context
-  if ($LASTEXITCODE -ne 0) {
-    throw "Docker rebuild failed. See output above. Dockerfile='$Dockerfile' Context='$Context'"
-  }
+  Write-Warning "-Rebuild ignored because -Local not set (using registry image)"
 }
 
 # Build full argument list explicitly to avoid parser quirks

--- a/utils/TuDa.CIMS.AssetItemImporter/run-container-attach.ps1
+++ b/utils/TuDa.CIMS.AssetItemImporter/run-container-attach.ps1
@@ -24,7 +24,7 @@ $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $RepoRoot = (Resolve-Path (Join-Path $ScriptDir '..\..')).Path
 
 # Default to registry image to match docker-compose; allow override via param or env.
-$DefaultRegistryImage = 'ghcr.io/projectcims/cims-asset-importer:latest'
+$DefaultRegistryImage = 'ghcr.io/projectcims/cims-asset-item-importer:latest'
 $Image = if ($PSBoundParameters.ContainsKey('Image')) { $Image } elseif ($env:IMAGE) { $env:IMAGE } else { $DefaultRegistryImage }
 
 # Default Dockerfile/Context anchored at repo root; allow env overrides
@@ -50,7 +50,7 @@ $mount = ($FullPath + ':/work')
 if ($Local) {
   if (-not $PSBoundParameters.ContainsKey('Image') -and -not $env:IMAGE -and $Image -eq $DefaultRegistryImage) {
     # If user didn't provide an image explicitly, use a sensible local default
-    $Image = 'cims-asset-importer:local'
+    $Image = 'cims-asset-item-importer:local'
   }
 
   Write-Host "Using Dockerfile: $Dockerfile"

--- a/utils/TuDa.CIMS.AssetItemImporter/run-container-attach.sh
+++ b/utils/TuDa.CIMS.AssetItemImporter/run-container-attach.sh
@@ -17,16 +17,16 @@ set -euo pipefail
 #   ./utils/TuDa.CIMS.AssetItemImporter/run-container-attach.sh [--local] [--rebuild] [--image <tag>] <host-workdir> [extra docker args]
 #
 # Env overrides:
-#   IMAGE       - image tag to use (default: ghcr.io/projectcims/cims-asset-importer:latest)
+#   IMAGE       - image tag to use (default: ghcr.io/projectcims/cims-asset-item-importer:latest)
 #   DOCKERFILE  - Dockerfile to use when building locally
 #   CONTEXT     - build context when building locally
 #   REBUILD     - if "1", force rebuild on local build
 
 set -euo pipefail
 
-IMAGE_DEFAULT="ghcr.io/projectcims/cims-asset-importer:latest"
+IMAGE_DEFAULT="ghcr.io/projectcims/cims-asset-item-importer:latest"
 IMAGE="${IMAGE:-$IMAGE_DEFAULT}"
-LOCAL_IMAGE_DEFAULT="cims-asset-importer:local"
+LOCAL_IMAGE_DEFAULT="cims-asset-item-importer:local"
 DOCKERFILE="${DOCKERFILE:-utils/TuDa.CIMS.AssetItemImporter/Dockerfile}"
 CONTEXT="${CONTEXT:-.}"
 REBUILD_FLAG="${REBUILD:-0}"

--- a/utils/TuDa.CIMS.AssetItemImporter/run-container-attach.sh
+++ b/utils/TuDa.CIMS.AssetItemImporter/run-container-attach.sh
@@ -9,33 +9,87 @@ fi
 set -euo pipefail
 
 # Starts the AssetItemImporter container with a provided work directory and attaches a shell.
-# Usage: ./utils/TuDa.CIMS.AssetItemImporter/run-container-attach.sh <host-workdir> [extra docker args]
+#
+# Default: uses prebuilt registry image (same registry style as docker-compose).
+# Local build: pass --local to use a local image tag and build if needed.
+#
+# Usage:
+#   ./utils/TuDa.CIMS.AssetItemImporter/run-container-attach.sh [--local] [--rebuild] [--image <tag>] <host-workdir> [extra docker args]
+#
+# Env overrides:
+#   IMAGE       - image tag to use (default: ghcr.io/projectcims/cims-asset-importer:latest)
+#   DOCKERFILE  - Dockerfile to use when building locally
+#   CONTEXT     - build context when building locally
+#   REBUILD     - if "1", force rebuild on local build
 
-IMAGE="${IMAGE:-cims-asset-importer:local}"
+set -euo pipefail
+
+IMAGE_DEFAULT="ghcr.io/projectcims/cims-asset-importer:latest"
+IMAGE="${IMAGE:-$IMAGE_DEFAULT}"
+LOCAL_IMAGE_DEFAULT="cims-asset-importer:local"
 DOCKERFILE="${DOCKERFILE:-utils/TuDa.CIMS.AssetItemImporter/Dockerfile}"
 CONTEXT="${CONTEXT:-.}"
 REBUILD_FLAG="${REBUILD:-0}"
+USE_LOCAL=0
+WORKDIR=""
 
-if [[ $# -lt 1 ]]; then
-  echo "Usage: $0 <host-workdir> [extra docker args]" >&2
+print_usage() {
+  echo "Usage: $0 [--local] [--rebuild] [--image <tag>] <host-workdir> [extra docker args]" >&2
+}
+
+# Parse flags and positional args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --local)
+      USE_LOCAL=1
+      # If user didn't explicitly set IMAGE via env, use local default
+      if [[ "${IMAGE:-}" == "$IMAGE_DEFAULT" ]]; then
+        IMAGE="$LOCAL_IMAGE_DEFAULT"
+      fi
+      shift
+      ;;
+    --rebuild)
+      REBUILD_FLAG=1
+      shift
+      ;;
+    --image)
+      [[ $# -ge 2 ]] || { echo "--image requires a value" >&2; exit 2; }
+      IMAGE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      if [[ -z "$WORKDIR" ]]; then
+        WORKDIR="$1"
+        shift
+      else
+        break
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$WORKDIR" ]]; then
+  print_usage
   exit 1
 fi
 
-WORKDIR="$1"; shift || true
-
-# Optional --rebuild flag triggers a force build
-if [[ "${1:-}" == "--rebuild" ]]; then
-  REBUILD_FLAG=1
-  shift
-fi
-
-# Build the image if it doesn't exist locally, or if rebuild requested.
-if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-  echo "Image '$IMAGE' not found locally. Building..."
-  docker build -t "$IMAGE" -f "$DOCKERFILE" "$CONTEXT"
-elif [[ "$REBUILD_FLAG" == "1" ]]; then
-  echo "Rebuilding image '$IMAGE' ..."
-  docker build --no-cache -t "$IMAGE" -f "$DOCKERFILE" "$CONTEXT"
+# If using local image, build if missing or if rebuild requested.
+if [[ "$USE_LOCAL" == "1" ]]; then
+  if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo "Local image '$IMAGE' not found. Building..."
+    docker build -t "$IMAGE" -f "$DOCKERFILE" "$CONTEXT"
+  elif [[ "$REBUILD_FLAG" == "1" ]]; then
+    echo "Rebuilding local image '$IMAGE' ..."
+    docker build --no-cache -t "$IMAGE" -f "$DOCKERFILE" "$CONTEXT"
+  fi
+else
+  if [[ "$REBUILD_FLAG" == "1" ]]; then
+    echo "Warning: --rebuild ignored because --local not set (using registry image)" >&2
+  fi
 fi
 
 # Attach an interactive shell with the workdir mounted.


### PR DESCRIPTION
This pull request refactors the container usage workflow for the AssetItemImporter utility, making it easier and more consistent to run the importer either with a prebuilt registry image or a locally built image. The changes improve usability, clarify documentation, and unify behavior between the shell (`.sh`) and PowerShell (`.ps1`) scripts.

**Improvements to container usage and workflow:**

* Updated the documentation in `README.md` to clarify the default behavior (using the registry image), and added explicit instructions for using a local image and rebuilding it.

**Enhancements to shell and PowerShell scripts:**

* Refactored `run-container-attach.sh` to support new flags (`--local`, `--rebuild`, `--image <tag>`), improved argument parsing, and clarified usage/help messaging. The script now defaults to the registry image unless `--local` is specified, and only rebuilds the image when appropriate.
* Refactored `run-container-attach.ps1` to match the shell script's logic: added support for `-Local`, `-Rebuild`, and `-Image` parameters, improved default image selection, and clarified error handling and usage instructions. [[1]](diffhunk://#diff-b16a75bbc9f56b746b3322d05b5a51c7d74f6aa9871cf241e2bea9a7d2911eceL5-R13) [[2]](diffhunk://#diff-b16a75bbc9f56b746b3322d05b5a51c7d74f6aa9871cf241e2bea9a7d2911eceL24-R28) [[3]](diffhunk://#diff-b16a75bbc9f56b746b3322d05b5a51c7d74f6aa9871cf241e2bea9a7d2911eceL33-R75)

These changes make the workflow more predictable and user-friendly, ensuring both scripts behave consistently and are easier to use for both local development and production scenarios.